### PR TITLE
【新增】Fuclaude 通配子域名的支持和说明 【修复】新玩具 Fuclaude页面的更多探索表头问题

### DIFF
--- a/src/pages/Fuclaude/_meta.json
+++ b/src/pages/Fuclaude/_meta.json
@@ -1,4 +1,5 @@
 {
   "session_token": "Session Token",
-  "fuclaude": "Fuclaude 镜像"
+  "fuclaude": "Fuclaude 镜像",
+  "every": "通配子域名"
 }

--- a/src/pages/Fuclaude/every.mdx
+++ b/src/pages/Fuclaude/every.mdx
@@ -1,0 +1,12 @@
+import Image from "next/image";
+import Link from "next/link";
+
+## 通配子域名
+
+fuclaude.oaifree.com 支持使用通配子域名。
+
+你可以使用 <Link href="https://linuxdo.fuclaude.oaifree.com" target="\_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>linuxdo.fuclaude.oaifree.com</Link> 、 <Link href="https://oaifree.fuclaude.oaifree.com" target="\_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>oaifree.fuclaude.oaifree.com</Link> 等子域名来访问镜像服务。
+
+事实上，`*.fuclaude.oaifree.com` 的这个前缀 `*` 可以是满足域名规则的任意字符。
+
+但是，不同域名的 Cookie 是不通用的，应该一定程度防止一些阻断。

--- a/src/pages/Fuclaude/fuclaude.mdx
+++ b/src/pages/Fuclaude/fuclaude.mdx
@@ -70,6 +70,7 @@ services:
 ```
 
 ### 热佬教程
+
 |<div style={{ width: '150px', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>平台</div>| <div style={{ width: '370px', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>帖子</div> | <div style={{ width: '200px', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>作者</div> |
 |------|------|:------:|
 | Mac | <Link href="https://linux.do/t/topic/131633" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Mac 部署 Fuclaude</Link>                | @Leon01                        |
@@ -169,12 +170,8 @@ fetch(url, {
 
 ## 更多探索
 
-|<div style={{ width: '550px', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>标题</div>| <div style={{ width: '200px', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>作者</div> |
-|------|:------:|
 - <Link href="https://linux.do/t/topic/131611" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>闲来无事搓的一个小玩具</Link>
 - <Link href="https://linux.do/t/topic/136358" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Fuclaude 食用指南</Link>
 - <Link href="https://linux.do/t/topic/134197" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>小玩具也能有炸裂功能</Link>
 - <Link href="https://linux.do/t/topic/155769" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>你们新注册的Claude账号还好吗？</Link>
 - <Link href="https://linux.do/t/topic/135785" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>建立一个 Fuclaude Shared Chat 的第二步</Link>
-
-


### PR DESCRIPTION
📝 文档(fuclaude.mdx)：更新格式和链接，移除冗余内容