### PR TITLE
【改进】优化荣誉榜卡片显示样式，修复链接错误 Close #51

### DIFF
--- a/components/Card.module.css
+++ b/components/Card.module.css
@@ -4,6 +4,7 @@
   height: 154px;
   perspective: 1000px;
   color: white;
+  place-self: center;
 }
 
 .flipCardInner {

--- a/components/GoldCard.module.css
+++ b/components/GoldCard.module.css
@@ -4,6 +4,7 @@
   height: 154px;
   perspective: 1000px;
   color: white;
+  place-self: center;
 }
 
 .heading_8264 {

--- a/src/pages/Fuclaude/fuclaude.mdx
+++ b/src/pages/Fuclaude/fuclaude.mdx
@@ -77,9 +77,9 @@ services:
 |------|------|:------:|
 | Mac | <Link href="https://linux.do/t/topic/131633" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Mac 部署 Fuclaude</Link>                | @Leon01                        |
 | Windows | <Link href="https://linux.do/t/topic/131968" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Windows 部署 Fuclaude</Link>            | @likoo                         |
-| Docker | <Link href="https://linux.do/t/topic/131669" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Docker 部署 Fuclaude</Link>             | @Clever Hu                     |
+| Docker | <Link href="https://linux.do/t/topic/131820" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Docker 部署 Fuclaude</Link>             | @Clever Hu                     |
 | Docker For Win | <Link href="https://linux.do/t/topic/134758" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Docker For Win 部署 Fuclaude</Link>    | @likoo                         |
-| 群晖nas | <Link href="https://linux.do/t/topic/131820" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>群晖nas 部署 Fuclaude</Link>            | @King-Huiwen-of-Qin            |
+| 群晖nas | <Link href="https://linux.do/t/topic/131669" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>群晖nas 部署 Fuclaude</Link>            | @King-Huiwen-of-Qin            |
 | Serv00 | <Link href="https://linux.do/t/topic/132575" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Serv00 部署 Fuclaude 1</Link>           | @cself                         |
 | Serv00 | <Link href="https://linux.do/t/topic/131799" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Serv00 部署 Fuclaude 2</Link>           | @Mingyu                        |
 | Huggingface | <Link href="https://linux.do/t/topic/134344" target="_blank" style={{ textDecoration: 'none', color: '#3A9FE8' }}>Huggingface 部署 Fuclaude</Link>        | @kingtest                      |


### PR DESCRIPTION
1. 修复部分话题链接错误 Link #51 
2. 优化荣誉榜卡片在小屏幕单行显示时样式

之前：
![before](https://github.com/user-attachments/assets/12c3221e-180d-4241-92ed-4a2c921c1067)
之后
![after](https://github.com/user-attachments/assets/5952ad14-48aa-448a-8c11-33d2beef568f)
