### PR TITLE
[建议]临时将本页面中的 TopicHoverCard 替换为普通话题链接。

### DIFF
--- a/content/Community/LinuxDoMetaverse.mdx
+++ b/content/Community/LinuxDoMetaverse.mdx
@@ -21,10 +21,10 @@ import { TopicHoverCard } from '@/components/common/TopicHoverCard'
 
 | 站点 | 相关资料 | 元宇宙作者 |
 | --- | --- | --- |
-| <Link href='https://wiki.linux.do/' target='_blank' className='text-blue-500'>wiki.linux.do</Link> | <TopicHoverCard topicId='131633' defaultTitle='Linux Do 官方 Wiki 文档站' /> | <UserHoverCard username='Chenyme' /> |
-| <Link href='https://nav.linux.do/' target='_blank' className='text-blue-500'>nav.linux.do</Link> | <TopicHoverCard topicId='121796' defaultTitle='Linux DO 官方服务导航站' /> | <UserHoverCard username='蕾丝蝙蝠侠' /> |
-| <Link href='https://lottery.linux.do/' target='_blank' className='text-blue-500'>lottery.linux.do</Link> | <TopicHoverCard topicId='211016' defaultTitle='LINUX DO 官方抽奖工具' /> | <UserHoverCard username='musifei' /> |
-| <Link href='https://webmail.linux.do/' target='_blank' className='text-blue-500'>webmail.linux.do</Link> | <TopicHoverCard topicId='451470' defaultTitle='LINUX DO 官方 Mail 邮箱' /> | <UserHoverCard username='Neo' /> |
+| <Link href='https://wiki.linux.do/' target='_blank' className='text-blue-500'>wiki.linux.do</Link> | <Link href='https://linux.do/t/topic/131633' target='_blank' className='text-blue-500'>Linux Do 官方 Wiki 文档站</Link> | <UserHoverCard username='Chenyme' /> |
+| <Link href='https://nav.linux.do/' target='_blank' className='text-blue-500'>nav.linux.do</Link> | <Link href='https://linux.do/t/topic/121796' target='_blank' className='text-blue-500'>Linux DO 官方服务导航站</Link> | <UserHoverCard username='蕾丝蝙蝠侠' /> |
+| <Link href='https://lottery.linux.do/' target='_blank' className='text-blue-500'>lottery.linux.do</Link> | <Link href='https://linux.do/t/topic/211016' target='_blank' className='text-blue-500'>LINUX DO 官方抽奖工具</Link> | <UserHoverCard username='musifei' /> |
+| <Link href='https://webmail.linux.do/' target='_blank' className='text-blue-500'>webmail.linux.do</Link> | <Link href='https://linux.do/t/topic/451470' target='_blank' className='text-blue-500'>LINUX DO 官方 Mail 邮箱</Link> | <UserHoverCard username='Neo' /> |
 | <Link href='https://status.linux.do/' target='_blank' className='text-blue-500'>status.linux.do</Link> | Linux Do 社区相关服务监控 | <UserHoverCard username='Neo' /> |
 
 我们诚挚邀请更多社区成员参与 Linux DO 元宇宙 的建设，让我们携手共创社区的美好未来！


### PR DESCRIPTION
当前 TopicHoverCard 在渲染接口返回的标签对象时会触发 React error #31， 鼠标悬停后可能导致整个页面白屏。此修改仅用于恢复页面可用性，
待 TopicHoverCard 完成对对象格式标签的兼容后，可以再恢复悬浮卡片。

社区个人主页链接：https://linux.do/u/suiying